### PR TITLE
fix apidocs not-found bug

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -20,7 +20,7 @@
 
 <body>
     <!-- we provide the specification here -->
-    <redoc spec-url='./openApi3.yml' expand-responses="all"></redoc>
+    <redoc spec-url='/docs/openApi3.yml' expand-responses="all"></redoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
 </body>
 

--- a/src/app.js
+++ b/src/app.js
@@ -10,6 +10,8 @@ syncOpenApi2and3Docs();
 
 const app = express();
 
+app.use('/docs', express.static('docs'));
+
 app.use(bodyParser.json());
 app.use('/api/v1/', v1Routes);
 app.use(middleware.errorHandler.handleErrors);

--- a/test/api/v1/api-docs.route.test.js
+++ b/test/api/v1/api-docs.route.test.js
@@ -11,6 +11,7 @@ describe('/api/v1', function () {
                 expect(res.text).to.include('<title>LeagueTracker Docs</title>');
                 expect(res.text).to.include('<redoc');
                 expect(res.text).to.include('</redoc>');
+                // Note: the DOM may still error. See https://github.com/rwalle61/leaguetracker/issues/83
             });
         });
         describe('/swagger', function () {


### PR DESCRIPTION
hopefully this will fix the /api-docs route without breaking github's hosting of the docs at /docs on master